### PR TITLE
Multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,73 @@
+https://circleci.com/gh/jeanlaurent/stupid/tree/master
+
+# Stupid
+
+A stupid tool to write a portable `Makefile` for a `Go` project.
+
+It provides simple commands to bridge the differences between the behaviors of the shells invoked from a typical `Makefile` by `GNU Make`.
+
+All commands which manipulate files and directories should take linux-style paths as inputs, e.g. be made of forward slashes.
+
+Available commands:
+* [cp](#cp)
+* [home](#home)
+* [rm](#rm)
+
+## Installation
+
+```
+go get -u github.com/jeanlaurent/stupid
+```
+
+Most systems have `GNU Make` available through their package manager.
+For Windows the [GnuWin32 Make](http://gnuwin32.sourceforge.net/packages/make.htm) albeit a bit outdated has been known to work well.
+
+## Commands
+
+### cp
+
+```
+stupid cp SRCS DST
+```
+Copies files and directories listed in `SRCS` into `DST`, with the following behavior:
+* existing files are overwritten
+* copying is recursive
+* intermediate directories are created
+* permissions are replicated
+* `DST` is a directory if any of the following is true:
+  * `DST` already exists and is a directory
+  * `DST` ends with a trailing slash
+  * `SRCS` has more than one source
+  * `SRCS` is a single source directory
+* `DST` is a file if one of the following is true
+  * `DST` already exists and is a file
+  * `SRCS` is a single source file and `DST` does not end with a trailing slash
+
+Example:
+```
+stupid cp web/readme.txt web/dist/* electron/web
+```
+### home
+```
+stupid home
+```
+Prints the home directory of the current user.
+
+The exact format is platform dependent (e.g. the result can contain back or forward slashes or both) and may contain spaces, therefore it should be quoted when used.
+
+Example:
+```
+stupid cp build/library.yaml "$(shell stupid home)/.tootool/"
+```
+
+### rm
+```
+stupid rm SRCS
+```
+Removes the files and directories listed in `SRCS`, with the following behavior:
+* non existing sources are ignored
+
+Example:
+```
+stupid rm build/*.tar.gz electron/web
+```

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 		fmt.Print(home)
 	case "rm":
 		checkArguments(args, 2)
-		err = remove(args[1])
+		err = remove(args[1:])
 	case "cp":
 		checkArguments(args, 3)
 		err = copy(args[1], args[2])
@@ -58,17 +58,25 @@ func printUsage() {
 	fmt.Println("I'm stupidly copying or removing files and directories")
 	fmt.Println("* stupid home")
 	fmt.Println("* stupid cp SRC DST")
-	fmt.Println("* stupid rm SRC")
+	fmt.Println("* stupid rm SRCS")
 }
 
-func remove(source string) error {
-	fmt.Println("Removing", source)
-	_, err := os.Stat(source)
-	if os.IsNotExist(err) {
-		fmt.Printf("Source [%v] does not exist, doing nothing\n", source)
-		return nil
+func remove(sources []string) error {
+	for _, source := range sources {
+		fmt.Println("Removing", source)
+		_, err := os.Stat(source)
+		if os.IsNotExist(err) {
+			fmt.Printf("Source [%v] does not exist, doing nothing\n", source)
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if err = os.RemoveAll(source); err != nil {
+			return err
+		}
 	}
-	return os.RemoveAll(source)
+	return nil
 }
 
 func copy(source, destination string) error {

--- a/main.go
+++ b/main.go
@@ -24,11 +24,9 @@ func main() {
 		printUsage()
 	case "home":
 		home, err := homedir.Dir()
-		if err != nil {
-			fmt.Println(err.Error())
-			os.Exit(-3)
+		if err == nil {
+			fmt.Print(home)
 		}
-		fmt.Print(home)
 	case "rm":
 		checkArguments(args, 2)
 		err = remove(args[1:])

--- a/main.go
+++ b/main.go
@@ -62,6 +62,10 @@ func printUsage() {
 }
 
 func remove(sources []string) error {
+	sources, err := glob(sources)
+	if err != nil {
+		return err
+	}
 	for _, source := range sources {
 		fmt.Println("Removing", source)
 		_, err := os.Stat(source)
@@ -77,6 +81,18 @@ func remove(sources []string) error {
 		}
 	}
 	return nil
+}
+
+func glob(sources []string) ([]string, error) {
+	var paths []string
+	for _, source := range sources {
+		matches, err := filepath.Glob(source)
+		if err != nil {
+			return nil, err
+		}
+		paths = append(paths, matches...)
+	}
+	return paths, nil
 }
 
 func copy(source, destination string) error {

--- a/main.go
+++ b/main.go
@@ -123,6 +123,7 @@ func copy(sources []string, destination string) error {
 		}
 		dest := filepath.Join(destination, filepath.Base(source))
 		if info.IsDir() {
+			fmt.Printf("Copying dir [%v] to [%v]\n", source, dest)
 			if err = copyDirectory(source, dest); err != nil {
 				return err
 			}
@@ -138,6 +139,7 @@ func copy(sources []string, destination string) error {
 		if err = os.MkdirAll(filepath.Dir(dest), sourceDirInfo.Mode()); err != nil {
 			return err
 		}
+		fmt.Printf("Copying file [%v] to [%v]\n", source, dest)
 		if err = copyFile(source, dest); err != nil {
 			return err
 		}
@@ -146,7 +148,6 @@ func copy(sources []string, destination string) error {
 }
 
 func copyFile(src, dst string) error {
-	fmt.Printf("Copying file [%v] to [%v]\n", src, dst)
 	source, err := os.Open(src)
 	if err != nil {
 		return err
@@ -168,7 +169,6 @@ func copyFile(src, dst string) error {
 }
 
 func copyDirectory(src string, dst string) error {
-	fmt.Printf("Copying dir [%v] to [%v]\n", src, dst)
 	info, err := os.Stat(src)
 	if err != nil {
 		return err

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -50,59 +51,150 @@ func TestRemoveWithGlob(t *testing.T) {
 	assert.Assert(t, fs.Equal(rootDirectory.Path(), expected))
 }
 
-func TestCopyFile(t *testing.T) {
+func TestCopyFileToNonExistingFile(t *testing.T) {
 	rootDirectory := fs.NewDir(t, "root",
-		fs.WithFile("foo.txt", "foo\n"))
+		fs.WithFile("foo.txt", "foo"))
 	defer rootDirectory.Remove()
 
-	err := copy(filepath.Join(rootDirectory.Path(), "foo.txt"), filepath.Join(rootDirectory.Path(), "bar.txt"))
+	err := copy([]string{filepath.Join(rootDirectory.Path(), "foo.txt")}, filepath.Join(rootDirectory.Path(), "bar.txt"))
 	assert.NilError(t, err)
 
 	expected := fs.Expected(t,
-		fs.WithFile("foo.txt", "foo\n"),
-		fs.WithFile("bar.txt", "foo\n"))
+		fs.WithFile("foo.txt", "foo"),
+		fs.WithFile("bar.txt", "foo"))
 	assert.Assert(t, fs.Equal(rootDirectory.Path(), expected))
 }
 
-func TestCopyFileInNonExistingPath(t *testing.T) {
+func TestCopyFileToExistingFile(t *testing.T) {
 	rootDirectory := fs.NewDir(t, "root",
-		fs.WithFile("foo.txt", "foo\n"))
+		fs.WithFile("foo.txt", "foo"),
+		fs.WithFile("bar.txt", "bar"))
 	defer rootDirectory.Remove()
 
-	err := copy(filepath.Join(rootDirectory.Path(), "foo.txt"), filepath.Join(rootDirectory.Path(), "bar", "bar.txt"))
+	err := copy([]string{filepath.Join(rootDirectory.Path(), "foo.txt")}, filepath.Join(rootDirectory.Path(), "bar.txt"))
 	assert.NilError(t, err)
 
 	expected := fs.Expected(t,
-		fs.WithFile("foo.txt", "foo\n"),
+		fs.WithFile("foo.txt", "foo"),
+		fs.WithFile("bar.txt", "foo"))
+	assert.Assert(t, fs.Equal(rootDirectory.Path(), expected))
+}
+
+func TestCopyFileToNonExistingDir(t *testing.T) {
+	rootDirectory := fs.NewDir(t, "root",
+		fs.WithFile("foo.txt", "foo"))
+	defer rootDirectory.Remove()
+
+	err := copy([]string{filepath.Join(rootDirectory.Path(), "foo.txt")}, filepath.Join(rootDirectory.Path(), "destination")+"/")
+	assert.NilError(t, err)
+
+	info, err := os.Stat(rootDirectory.Path())
+	assert.NilError(t, err)
+	expected := fs.Expected(t,
+		fs.WithFile("foo.txt", "foo"),
+		fs.WithDir("destination",
+			fs.WithMode(info.Mode()),
+			fs.WithFile("foo.txt", "foo")))
+	assert.Assert(t, fs.Equal(rootDirectory.Path(), expected))
+}
+
+func TestCopyFileToExistingDir(t *testing.T) {
+	rootDirectory := fs.NewDir(t, "root",
+		fs.WithFile("foo.txt", "foo"),
+		fs.WithDir("destination"))
+	defer rootDirectory.Remove()
+
+	err := copy([]string{filepath.Join(rootDirectory.Path(), "foo.txt")}, filepath.Join(rootDirectory.Path(), "destination"))
+	assert.NilError(t, err)
+
+	expected := fs.Expected(t,
+		fs.WithFile("foo.txt", "foo"),
+		fs.WithDir("destination",
+			fs.WithFile("foo.txt", "foo")))
+	assert.Assert(t, fs.Equal(rootDirectory.Path(), expected))
+}
+
+func TestCopyMultipleFilesToFileFails(t *testing.T) {
+	rootDirectory := fs.NewDir(t, "root",
+		fs.WithFile("foo.txt", "foo"),
+		fs.WithFile("bar.txt", "bar"))
+	defer rootDirectory.Remove()
+
+	err := copy(
+		[]string{
+			filepath.Join(rootDirectory.Path(), "foo.txt"),
+			filepath.Join(rootDirectory.Path(), "foo.txt"),
+		}, filepath.Join(rootDirectory.Path(), "bar.txt"))
+	assert.Error(t, err, "Only one source file allowed when destination is a file")
+}
+
+func TestCopyFileToNonExistingPath(t *testing.T) {
+	rootDirectory := fs.NewDir(t, "root",
+		fs.WithFile("foo.txt", "foo"))
+	defer rootDirectory.Remove()
+
+	err := copy([]string{filepath.Join(rootDirectory.Path(), "foo.txt")}, filepath.Join(rootDirectory.Path(), "bar", "bar.txt"))
+	assert.NilError(t, err)
+
+	expected := fs.Expected(t,
+		fs.WithFile("foo.txt", "foo"),
 		fs.WithDir("bar", fs.WithMode(0700),
-			fs.WithFile("bar.txt", "foo\n")),
+			fs.WithFile("bar.txt", "foo")),
 	)
 	assert.Assert(t, fs.Equal(rootDirectory.Path(), expected))
 }
 
-func TestCopyTree(t *testing.T) {
+func TestCopyTreeToNonExistingPath(t *testing.T) {
 	rootDirectory := fs.NewDir(t, "root",
 		fs.WithDir("source",
-			fs.WithFile("foo.txt", "foo\n"),
+			fs.WithFile("foo.txt", "foo"),
 			fs.WithDir("bar",
-				fs.WithFile("bar.txt", "bar\n")),
+				fs.WithFile("bar.txt", "bar")),
 		),
 	)
 	defer rootDirectory.Remove()
 
-	err := copy(filepath.Join(rootDirectory.Path(), "source"), filepath.Join(rootDirectory.Path(), "destination"))
+	err := copy([]string{filepath.Join(rootDirectory.Path(), "source", "bar")}, filepath.Join(rootDirectory.Path(), "destination"))
 	assert.NilError(t, err)
 
 	expected := fs.Expected(t,
 		fs.WithDir("source",
-			fs.WithFile("foo.txt", "foo\n"),
+			fs.WithFile("foo.txt", "foo"),
 			fs.WithDir("bar",
-				fs.WithFile("bar.txt", "bar\n")),
+				fs.WithFile("bar.txt", "bar")),
 		),
 		fs.WithDir("destination",
-			fs.WithFile("foo.txt", "foo\n"),
 			fs.WithDir("bar",
-				fs.WithFile("bar.txt", "bar\n")),
+				fs.WithFile("bar.txt", "bar")),
+		),
+	)
+
+	assert.Assert(t, fs.Equal(rootDirectory.Path(), expected))
+}
+
+func TestCopyTreeWithGlob(t *testing.T) {
+	rootDirectory := fs.NewDir(t, "root",
+		fs.WithDir("source",
+			fs.WithFile("foo.txt", "foo"),
+			fs.WithDir("bar",
+				fs.WithFile("bar.txt", "bar")),
+		),
+	)
+	defer rootDirectory.Remove()
+
+	err := copy([]string{filepath.Join(rootDirectory.Path(), "source", "*")}, filepath.Join(rootDirectory.Path(), "destination"))
+	assert.NilError(t, err)
+
+	expected := fs.Expected(t,
+		fs.WithDir("source",
+			fs.WithFile("foo.txt", "foo"),
+			fs.WithDir("bar",
+				fs.WithFile("bar.txt", "bar")),
+		),
+		fs.WithDir("destination",
+			fs.WithFile("foo.txt", "foo"),
+			fs.WithDir("bar",
+				fs.WithFile("bar.txt", "bar")),
 		),
 	)
 

--- a/main_test.go
+++ b/main_test.go
@@ -32,6 +32,24 @@ func TestRemove(t *testing.T) {
 	assert.Assert(t, fs.Equal(rootDirectory.Path(), expected))
 }
 
+func TestRemoveWithGlob(t *testing.T) {
+	rootDirectory := fs.NewDir(t, "root",
+		fs.WithDir("empty-dir"),
+		fs.WithDir("full-dir",
+			fs.WithFile("some-file", "")),
+		fs.WithFile("remaining-file", ""))
+	defer rootDirectory.Remove()
+
+	err := remove([]string{
+		filepath.Join(rootDirectory.Path(), "*-dir"),
+		filepath.Join(rootDirectory.Path(), "full-dir"),
+	})
+	assert.NilError(t, err)
+
+	expected := fs.Expected(t, fs.WithFile("remaining-file", ""))
+	assert.Assert(t, fs.Equal(rootDirectory.Path(), expected))
+}
+
 func TestCopyFile(t *testing.T) {
 	rootDirectory := fs.NewDir(t, "root",
 		fs.WithFile("foo.txt", "foo\n"))

--- a/main_test.go
+++ b/main_test.go
@@ -8,42 +8,27 @@ import (
 	"gotest.tools/fs"
 )
 
-func TestRemoveEmptyDirectory(t *testing.T) {
+func TestRemove(t *testing.T) {
 	rootDirectory := fs.NewDir(t, "root",
-		fs.WithDir("toBeDeleted"),
-		fs.WithDir("remaining"))
+		fs.WithDir("empty-dir"),
+		fs.WithDir("full-dir",
+			fs.WithFile("some-file", "")),
+		fs.WithFile("file", ""),
+		fs.WithFile("remaining-file", ""),
+		fs.WithDir("remaining-dir"))
 	defer rootDirectory.Remove()
 
-	err := remove(filepath.Join(rootDirectory.Path(), "toBeDeleted"))
+	err := remove([]string{
+		filepath.Join(rootDirectory.Path(), "empty-dir"),
+		filepath.Join(rootDirectory.Path(), "full-dir"),
+		filepath.Join(rootDirectory.Path(), "non-existing"),
+		filepath.Join(rootDirectory.Path(), "file"),
+	})
 	assert.NilError(t, err)
 
-	expected := fs.Expected(t, fs.WithDir("remaining"))
-	assert.Assert(t, fs.Equal(rootDirectory.Path(), expected))
-}
-
-func TestRemoveFullDirectory(t *testing.T) {
-	rootDirectory := fs.NewDir(t, "root",
-		fs.WithDir("toBeDeleted",
-			fs.WithFile("foo", "foobar")),
-		fs.WithDir("remaining"))
-	defer rootDirectory.Remove()
-
-	err := remove(filepath.Join(rootDirectory.Path(), "toBeDeleted"))
-	assert.NilError(t, err)
-
-	expected := fs.Expected(t, fs.WithDir("remaining"))
-	assert.Assert(t, fs.Equal(rootDirectory.Path(), expected))
-}
-
-func TestRemoveNonExistingDirectory(t *testing.T) {
-	rootDirectory := fs.NewDir(t, "root",
-		fs.WithDir("remaining"))
-	defer rootDirectory.Remove()
-
-	err := remove(filepath.Join(rootDirectory.Path(), "nonExisting"))
-	assert.NilError(t, err)
-
-	expected := fs.Expected(t, fs.WithDir("remaining"))
+	expected := fs.Expected(t,
+		fs.WithFile("remaining-file", ""),
+		fs.WithDir("remaining-dir"))
 	assert.Assert(t, fs.Equal(rootDirectory.Path(), expected))
 }
 


### PR DESCRIPTION
Adds multiple files as sources and globing.
⚠️ this breaks backward compatibility:
```
	stupid cp web/dist electron/web
```
should now be
```
	stupid cp web/dist/* electron/web
```

(PR is on top of https://github.com/jeanlaurent/stupid/pull/1)